### PR TITLE
Use new Xen Orchestra Monorepo and some other changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY xo-entry.sh /
 
 EXPOSE 8000
 
-VOLUME ["/var/lib/redis/", "/var/lib/xo-server"]
+VOLUME ["/var/lib/redis", "/var/lib/xo-server"]
 
 ENTRYPOINT ["/xo-entry.sh"]
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:jessie
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN useradd -d /app -r app && \
+    useradd -r redis && \
     mkdir -p /var/lib/xo-server && \
     mkdir -p /var/lib/xoa-backups && \
     chown -R app /var/lib/xo-server && \
@@ -35,8 +36,7 @@ RUN cd /app/packages/xo-server && yarn add xo-server-backup-reports xo-server-tr
 # Clean up
 RUN apt-get -qq purge build-essential make gcc git libpng-dev curl && \
     apt-get autoremove -qq && apt-get clean && \
-    rm -rf /usr/share/doc /usr/share/man /var/log/* /tmp/* && \
-    mkdir -p /var/log/redis
+    rm -rf /usr/share/doc /usr/share/man /var/log/* /tmp/*
 
 # Copy over entrypoint and daemon config files
 COPY xo-server.yaml /app/packages/xo-server/.xo-server.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN git clone --depth=1 -b stable http://github.com/vatesfr/xen-orchestra . && \
 
 # Build dependencies
 RUN yarn && yarn run build
-RUN cd /app/packages/xo-server && yarn add xo-server-backup-reports xo-server-transport-nagios xo-server-transport-email
+RUN cd /app/packages/xo-server && yarn add \
+    xo-server-backup-reports  \
+    xo-server-transport-nagios  \
+    xo-server-transport-email
 
 # Clean up
 RUN apt-get -qq purge build-essential make gcc git libpng-dev curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN git clone --depth=1 -b stable http://github.com/vatesfr/xo-server && \
 RUN cd xo-server/ && yarn && yarn run build && cd ..
 RUN cd xo-web/ && yarn && yarn run build
 
+# Add plugins
+RUN cd xo-server/ && yarn add xo-server-backup-reports xo-server-transport-nagios xo-server-transport-email
+
 # Clean up
 RUN apt-get -qq purge build-essential make gcc git libpng-dev curl && \
     apt-get autoremove -qq && apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,12 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     apt-get -qq update && apt-get install yarn
 
 # Clone code
-RUN git clone --depth=1 -b xo-server/stable http://github.com/vatesfr/xen-orchestra xo-server && \
-    git clone --depth=1 -b stable http://github.com/vatesfr/xo-web && \
-    rm -rf xo-server/.git xo-web/.git xo-server/sample.config.yaml
+RUN git clone --depth=1 -b stable http://github.com/vatesfr/xen-orchestra . && \
+    rm -rf .git packages/xo-server/sample.config.yaml
 
-# Build dependencies then cleanup
-RUN cd xo-server/ && yarn && yarn run build && cd ..
-RUN cd xo-web/ && yarn && yarn run build
-
-# Add plugins
-RUN cd xo-server/ && yarn add xo-server-backup-reports xo-server-transport-nagios xo-server-transport-email
+# Build dependencies
+RUN yarn && yarn run build
+RUN cd /app/packages/xo-server && yarn add xo-server-backup-reports xo-server-transport-nagios xo-server-transport-email
 
 # Clean up
 RUN apt-get -qq purge build-essential make gcc git libpng-dev curl && \
@@ -43,7 +39,7 @@ RUN apt-get -qq purge build-essential make gcc git libpng-dev curl && \
     mkdir -p /var/log/redis
 
 # Copy over entrypoint and daemon config files
-COPY xo-server.yaml /app/xo-server/.xo-server.yaml
+COPY xo-server.yaml /app/packages/xo-server/.xo-server.yaml
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY redis.conf /etc/redis/redis.conf
 COPY xo-entry.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 8000
 VOLUME ["/var/lib/redis", "/var/lib/xo-server"]
 
 ENTRYPOINT ["/xo-entry.sh"]
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN yarn && yarn run build
 RUN cd /app/packages/xo-server && yarn add \
     xo-server-backup-reports  \
     xo-server-transport-nagios  \
+    xo-server-transport-slack \
+    xo-server-usage-report  \
     xo-server-transport-email
 
 # Clean up

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     apt-get -qq update && apt-get install yarn
 
 # Clone code
-RUN git clone --depth=1 -b stable http://github.com/vatesfr/xo-server && \
+RUN git clone --depth=1 -b xo-server/stable http://github.com/vatesfr/xen-orchestra xo-server && \
     git clone --depth=1 -b stable http://github.com/vatesfr/xo-web && \
     rm -rf xo-server/.git xo-web/.git xo-server/sample.config.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -qq update && \
 
 # Install nodejs
 RUN curl -o /usr/local/bin/n https://raw.githubusercontent.com/visionmedia/n/master/bin/n && \
-        chmod +x /usr/local/bin/n && n 6.11.0
+    chmod +x /usr/local/bin/n && n lts
 
 # Install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/redis.conf
+++ b/redis.conf
@@ -5,7 +5,6 @@ bind 127.0.0.1
 timeout 0
 
 loglevel notice
-logfile /var/log/redis/redis-server.log
 
 databases 16
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -22,8 +22,8 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 command=/usr/bin/redis-server /etc/redis/redis.conf
 
 [program:xo]
-directory=/app/xo-server
-command=/app/xo-server/bin/xo-server /app/xo-server/.xo-server.yaml
+directory=/app/packages/xo-server/
+command=/app/packages/xo-server/bin/xo-server /app/packages/xo-server/.xo-server.yaml
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,6 +20,11 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:redis]
 command=/usr/bin/redis-server /etc/redis/redis.conf
+user=redis
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 
 [program:xo]
 directory=/app/packages/xo-server/

--- a/xo-entry.sh
+++ b/xo-entry.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
+chown -R redis /var/lib/redis
 chown app /var/lib/xo-server
 exec "$@"

--- a/xo-server.yaml
+++ b/xo-server.yaml
@@ -5,6 +5,6 @@ http:
       host: '0.0.0.0'
       port: 8000
   mounts:
-    '/': '/app/xo-web/dist/'
+      '/': '../xo-web/dist/'
 redis:
     uri: 'tcp://localhost:6379'

--- a/xo-server.yaml
+++ b/xo-server.yaml
@@ -7,4 +7,4 @@ http:
   mounts:
       '/': '../xo-web/dist/'
 redis:
-    uri: 'tcp://localhost:6379'
+    uri: 'redis://localhost:6379'


### PR DESCRIPTION
Hey! This is a bit larger pull request (sorry, did not find the time to submit the changes when I did them in my local working copy).

I saw there is another MR (#2) for the mono repo changes. If you prefer this one feel free to merge I will try to rebase my changes on that.

Just to summarise all changes in this MR:

- make the dockerfile work with the new monorepo layout of Xen Orchestra
- added some plugins (backup-reports, transport-nagios, transport-email, transport-slack and usage-report)
- use LTS node version
- run the redis process as a newly created redis user and don’t log to /var/log anymore
- explicitly set the supervisord config (This is recommended by supervisord when running as root)

If you want me to remove some of those changes feel free to comment.